### PR TITLE
fix: replace blanket --no-cache with --pull to bound build cache

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,8 +43,24 @@ if [ -z "${FORCE_DEPLOY:-}" ] && [ "$PREVIOUS_COMMIT" = "$CURRENT_COMMIT" ]; the
     log "No changes but unhealthy — rebuilding..."
 fi
 
+# Always --pull. Both Dockerfiles use floating base tags (python:3.11-slim,
+# node:22-alpine), so pulling is what actually picks up upstream security
+# patches. When the base digest changes every layer below FROM rebuilds anyway,
+# including the frontend's `apk upgrade` — which is the property the old blanket
+# --no-cache was really buying. When nothing upstream moved and deps are
+# unchanged, the cached layers are reused and no new ones accumulate.
+#
+# Blanket --no-cache rebuilt every layer on every deploy. With deploys firing as
+# often as every 5 minutes (heartbeat) it grew 51 GB of build cache and filled
+# the disk to 85%. Set FORCE_REBUILD=1 to opt back into a full clean rebuild.
+BUILD_ARGS=(--pull)
+if [ -n "${FORCE_REBUILD:-}" ]; then
+    log "FORCE_REBUILD set — full clean rebuild"
+    BUILD_ARGS+=(--no-cache)
+fi
+
 log "Building images..."
-docker compose -f "$COMPOSE_FILE" build --no-cache backend frontend
+docker compose -f "$COMPOSE_FILE" build "${BUILD_ARGS[@]}" backend frontend
 
 log "Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --force-recreate
@@ -54,6 +70,10 @@ for i in $(seq 1 "$MAX_RETRIES"); do
     if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
         log "Healthy (attempt $i). Deploy complete."
         docker image prune -f > /dev/null 2>&1
+        # Cap build-cache growth. Anything untouched for a week is not being
+        # reused by incremental builds, so dropping it costs nothing but keeps
+        # the 98 GB root from filling again.
+        docker builder prune -f --filter until=168h > /dev/null 2>&1 || true
         exit 0
     fi
     sleep "$INTERVAL"


### PR DESCRIPTION
## Problem

`deploy.sh` ran `docker compose build --no-cache` on every deploy. Between the 5-minute deploy heartbeat and the 30-minute content pipeline, deploys fire often — and every one rebuilt every layer from scratch.

Measured on the ProDesk before this change:

```
TYPE          TOTAL   ACTIVE   SIZE      RECLAIMABLE
Images        14      10       47.06GB   46.05GB (97%)
Build Cache   451     0        51.47GB   51.01GB
```

Root disk was at **85% (79 GB of 98 GB)** with 15 GB free. A manual prune reclaimed 48 GB, but without this change it simply regrows.

## What `--no-cache` was actually protecting

Two legitimate things, and `--pull` covers both:

1. **Floating base tags.** `backend/Dockerfile` uses `FROM python:3.11-slim`, `frontend/Dockerfile` uses `FROM node:22-alpine`. Without `--pull`, Docker reuses whatever base it already has locally — so `--no-cache` on its own would still rebuild against a stale base. `--pull` is what genuinely picks up upstream security patches.
2. **The `apk upgrade` layer.** `frontend/Dockerfile:11` runs `apk update && apk upgrade --no-cache`. Ordinary layer caching freezes that permanently. But when `--pull` fetches a new base digest, every layer below `FROM` is invalidated and the upgrade re-runs — precisely when there is something to upgrade.

When nothing upstream moved and dependencies are unchanged, layers are reused and none accumulate.

## Changes

- `build --no-cache` → `build --pull`
- `FORCE_REBUILD=1` opts back into a full clean rebuild when you want one
- After a healthy deploy, `docker builder prune -f --filter until=168h` drops cache unused for a week

## Trade-off

Deploys get faster in the common case. The one thing lost is a guaranteed clean rebuild when a base image is republished under the *same* digest — vanishingly rare, and `FORCE_REBUILD=1` covers it.

## Test plan

`bash -n scripts/deploy.sh` passes. After merge, the heartbeat or a push triggers a deploy; confirm on the server:

```bash
tail -20 $(ls -t /var/log/flower-deploy/*.log | head -1)   # expect 'Healthy', no errors
curl -sf http://127.0.0.1:8080/health
docker system df                                            # build cache should stay bounded
```