### PR TITLE
Fix WCAG AA text contrast (light + dark themes)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -99,7 +99,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-a { color: inherit; text-decoration: none; }
+/* Keep the link reset in @layer base so Tailwind text-* utilities
+   (emitted in @layer utilities) still win on anchors/Links. Without the
+   layer this unlayered rule beat every text-* utility, forcing e.g. the
+   forest-bg "Request a plant" Link to inherit --text (unreadable in light mode). */
+@layer base {
+  a { color: inherit; text-decoration: none; }
+}
 
 /* ─── Component: glass-card ─── */
 .glass-card {
@@ -172,7 +178,9 @@ a { color: inherit; text-decoration: none; }
 
 .dark {
   /* Override primary palette */
-  --forest:    #2E8B57;     /* lighter green for dark bg readability */
+  --forest:    #4CAF50;     /* AA-readable green as TEXT on dark cards (was #2E8B57 ~3.3:1);
+                               button backgrounds use explicit dark greens (#2D6A4F) so they
+                               keep enough contrast against white labels */
   --forest-50: #0f291e;
   --forest-100: #153628;
   --forest-200: #1B4332;
@@ -221,7 +229,7 @@ a { color: inherit; text-decoration: none; }
   --card-alt:  #0a2116;
   --text:      #FFF8F0;               /* cream text */
   --text-muted:#A7C4A0;               /* sage muted */
-  --text-soft: #6b8a65;
+  --text-soft: #93b08b;               /* lightened for AA on dark cards (was #6b8a65 ~4.0:1) */
   --border:    #1B4332;
   --border-soft: #153628;
 
@@ -252,8 +260,8 @@ a { color: inherit; text-decoration: none; }
 .dark .bg-gray-200 { background-color: #153628; }
 .dark .border-gray-100 { border-color: #1B4332; }
 .dark .border-gray-200 { border-color: #1B4332; }
-.dark .text-gray-300 { color: #4a7a5a; }
-.dark .text-gray-400 { color: #6b8a65; }
+.dark .text-gray-300 { color: #7fa276; }
+.dark .text-gray-400 { color: #93b08b; }
 .dark .text-gray-500 { color: #7daa75; }
 .dark .text-gray-600 { color: #A7C4A0; }
 .dark .text-gray-700 { color: #FFF8F0; }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -51,8 +51,8 @@ export default function RootLayout({
               <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-3 text-sm text-[var(--text-muted)] dark:text-[var(--text-muted)]">
                 <div className="flex items-center gap-1.5">
                   <span>🌱</span>
-                  <span className="font-semibold text-[var(--forest)]">
-                    auckland<span className="text-[var(--terracotta)]">.</span>garden
+                  <span className="font-semibold text-[var(--forest)] dark:text-[#4CAF50]">
+                    auckland<span className="text-[var(--terracotta-500)] dark:text-[var(--terracotta)]">.</span>garden
                   </span>
                 </div>
                 <p>A seasonal planner for Auckland, New Zealand</p>

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -340,7 +340,7 @@ export default function RequestPage() {
             <button
               type="submit"
               disabled={submitting || !q}
-              className="mt-4 flex items-center gap-2 px-5 py-2.5 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] transition disabled:opacity-50"
+              className="mt-4 flex items-center gap-2 px-5 py-2.5 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition disabled:opacity-50"
             >
               <Sprout size={16} />
               {submitting

--- a/frontend/src/components/AddToCalendarModal.tsx
+++ b/frontend/src/components/AddToCalendarModal.tsx
@@ -195,7 +195,7 @@ export default function AddToCalendarModal({
                     onClick={() => setAction(a)}
                     className={`px-3 py-1.5 rounded-full text-sm capitalize transition ${
                       action === a
-                        ? "bg-[var(--forest)] text-white"
+                        ? "bg-[var(--forest)] text-white dark:bg-[#2D6A4F]"
                         : "bg-gray-100 dark:bg-[var(--border)] hover:bg-[var(--forest-50)]"
                     }`}
                   >
@@ -267,7 +267,7 @@ export default function AddToCalendarModal({
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="flex-1 py-2 px-4 bg-[var(--forest)] text-white rounded-lg hover:opacity-90 disabled:opacity-50 transition font-medium"
+                className="flex-1 py-2 px-4 bg-[var(--forest)] dark:bg-[#2D6A4F] text-white rounded-lg hover:opacity-90 disabled:opacity-50 transition font-medium"
               >
                 {isSubmitting ? "Saving…" : "Save to calendar"}
               </button>

--- a/frontend/src/components/AddToMyGardenButton.tsx
+++ b/frontend/src/components/AddToMyGardenButton.tsx
@@ -117,7 +117,7 @@ export default function AddToMyGardenButton({
     <button
       onClick={handleAdd}
       disabled={isAdding}
-      className="flex items-center gap-2 px-4 py-2 text-sm border border-[var(--forest)] text-[var(--forest)] rounded-lg hover:bg-[var(--forest-50)] dark:hover:bg-[#153628]/50 disabled:opacity-50 transition"
+      className="flex items-center gap-2 px-4 py-2 text-sm border border-[var(--forest)] text-[var(--forest)] dark:border-[#4CAF50] dark:text-[#4CAF50] rounded-lg hover:bg-[var(--forest-50)] dark:hover:bg-[#153628]/50 disabled:opacity-50 transition"
     >
       <Heart size={16} />
       {isAdding ? "Adding…" : "Add to my garden"}

--- a/frontend/src/components/FlowerDashboardClient.tsx
+++ b/frontend/src/components/FlowerDashboardClient.tsx
@@ -56,7 +56,7 @@ export default function FlowerDashboardClient() {
           </button>
           <button
             onClick={() => openAuthModal("signup")}
-            className="px-4 py-2 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] transition"
+            className="px-4 py-2 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition"
           >
             Get started — free
           </button>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -62,7 +62,7 @@ export default function Nav() {
             <span className="font-bold text-base tracking-tight text-[var(--forest)] dark:text-[#4CAF50]">
               auckland
             </span>
-            <span className="text-[var(--terracotta)] font-bold text-base">.</span>
+            <span className="text-[var(--terracotta-500)] dark:text-[var(--terracotta)] font-bold text-base">.</span>
             <span className="font-bold text-base tracking-tight text-[var(--forest)] dark:text-[#4CAF50]">
               garden
             </span>
@@ -114,7 +114,7 @@ export default function Nav() {
           ) : (
             <button
               onClick={() => openAuthModal("signin")}
-              className="px-3 py-1.5 rounded-[var(--radius-sm)] text-sm font-medium bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] transition"
+              className="px-3 py-1.5 rounded-[var(--radius-sm)] text-sm font-medium bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition"
             >
               Sign in
             </button>
@@ -203,7 +203,7 @@ export default function Nav() {
                 <div className="h-px bg-[var(--border-soft)] dark:border-[var(--border)] my-1" />
                 <button
                   onClick={() => openAuthModal("signin")}
-                  className="px-3 py-3 rounded-[var(--radius-sm)] text-base font-medium text-left bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] transition"
+                  className="px-3 py-3 rounded-[var(--radius-sm)] text-base font-medium text-left bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition"
                 >
                   Sign in
                 </button>

--- a/frontend/src/components/RegionSelector.tsx
+++ b/frontend/src/components/RegionSelector.tsx
@@ -17,8 +17,8 @@ export default function RegionSelector() {
           onClick={() => setRegion(r.id)}
           className={`px-3 py-1.5 rounded-md text-sm font-medium transition cursor-pointer ${
             region === r.id
-              ? "bg-white dark:bg-[#0f291e] shadow-sm text-[var(--forest)]"
-              : "text-[var(--text-muted)] hover:text-[var(--forest)]"
+              ? "bg-white dark:bg-[#0f291e] shadow-sm text-[var(--forest)] dark:text-[#4CAF50]"
+              : "text-[var(--text-muted)] hover:text-[var(--forest)] dark:hover:text-[#4CAF50]"
           }`}
         >
           {r.emoji} {r.label}

--- a/frontend/src/components/VegDashboardClient.tsx
+++ b/frontend/src/components/VegDashboardClient.tsx
@@ -56,7 +56,7 @@ export default function VegDashboardClient() {
           </button>
           <button
             onClick={() => openAuthModal("signup")}
-            className="px-4 py-2 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] transition"
+            className="px-4 py-2 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition"
           >
             Get started — free
           </button>


### PR DESCRIPTION
## What
Full-site contrast audit (computed WCAG ratios, every route, both themes) found readability failures. Fixes all of them.

### Light mode
"Request a plant" header link was near-black on dark green (**1.57:1**). Root cause: `a { color: inherit }` was unlayered and beat every Tailwind `text-*` on links. Moved into `@layer base`.

### Dark mode
- `--forest` `#2E8B57 -> #4CAF50` (AA as text on dark cards: maori names, type badges, bird counts; ~70 elements).
- Primary buttons use explicit dark green `#2D6A4F` with white labels.
- Muted text `#6b8a65 -> #93b08b` ("N varieties", "Sow window", "Not this month").
- dark: overrides on region toggle, footer brand, add-to-garden; light logo dot -> terracotta-500.

## Verification
0 contrast failures on every route in both themes (card text confirmed on real prod data). `next lint` and `next build` clean. Colour tokens/variants only — no behaviour change.