### PR TITLE
Fix unreadable blue timing badges in dark mode

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -273,6 +273,10 @@ body {
 .dark .bg-blue-100 { background-color: #153628; }
 .dark .text-blue-700 { color: #66BB6A; }
 .dark .text-blue-600 { color: #4CAF50; }
+/* bg-blue-100 is remapped to dark green above, but text-blue-800 wasn't —
+   left dark-blue-on-dark-green (~1.4:1) on timing badges ("Opens in N weeks"),
+   the "Stake" tag, and the calendar Winter badge. Pair it with a light tint. */
+.dark .text-blue-800 { color: #8fc5ea; }
 .dark .border-blue-100 { border-color: #1B4332; }
 .dark .border-blue-200 { border-color: #1B4332; }
 .dark [class*="hover:bg-blue-100"]:hover { background-color: #1B4332; }


### PR DESCRIPTION
## What
The dark theme remaps `.bg-blue-100` → dark green (`#153628`) but never added a matching `text-blue-800` override, so the blue **timing badges** rendered dark-blue-on-dark-green — **~1.4:1**, effectively unreadable.

Affected (all use `bg-blue-100 text-blue-800`):
- "Opens in N weeks" / "Opens <month>" over-image pills on flower & vegetable cards
- the "Stake" tag on flower detail
- the **Winter** badge on the calendar

## Fix
One line — pair the existing bg override with a light-blue text override:
`.dark .text-blue-800 { color: #8fc5ea; }`

Measured on the live cards: **1.4:1 → 7.13:1**. Light mode untouched (rule is dark-only; it was already ~8:1).

## Why the first contrast pass missed it
That audit skipped any text overlaying an image (couldn't compute contrast against a photo) — which is exactly where these status pills live. Verified this fix directly on the live rendered badges this time.