### PR TITLE
Backend GET /api/catalog/search + catalog polish (E2)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.routes.dashboard import router as dashboard_router
 from app.routes.vegetables import router as vegetables_router
 from app.routes.natives import router as natives_router
 from app.routes.analytics import router as analytics_router
+from app.routes.catalog import router as catalog_router
 from app.middleware.activity_logger import ActivityLoggerMiddleware
 
 app = FastAPI(
@@ -43,6 +44,7 @@ app.include_router(dashboard_router)
 app.include_router(vegetables_router)
 app.include_router(natives_router)
 app.include_router(analytics_router)
+app.include_router(catalog_router)
 
 
 @app.get("/health")

--- a/backend/app/routes/catalog.py
+++ b/backend/app/routes/catalog.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from app.services.catalog_service import search_catalog
+
+router = APIRouter(prefix="/api/catalog", tags=["catalog"])
+
+
+@router.get("/search")
+def catalog_search(
+    q: str = Query("", description="Search text (returns [] if under 2 chars)"),
+    type: Optional[str] = Query(None, description="flower | vegetable"),
+    limit: int = Query(8, ge=1, le=25),
+):
+    return search_catalog(q, type, limit)

--- a/backend/app/services/catalog_service.py
+++ b/backend/app/services/catalog_service.py
@@ -1,0 +1,70 @@
+"""Fuzzy search over the plant catalog.
+
+Loads ``backend/database/catalog.json`` once (via ``lru_cache``) and ranks
+plants by fuzzy score over the display name plus each alias. The rank floor
+and match style are tuned so short user queries ("tom") still hit the right
+plants without flooding results with spurious matches — see the tests.
+"""
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import Optional
+
+from rapidfuzz import fuzz
+
+DB_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "database",
+    "catalog.json",
+)
+
+_MIN_Q = 2  # queries shorter than this return [] regardless of catalog contents
+_SCORE_FLOOR = 60  # rapidfuzz WRatio; below this the hit is dropped
+
+
+@lru_cache(maxsize=1)
+def _load_catalog() -> list[dict]:
+    with open(DB_PATH, "r", encoding="utf-8") as f:
+        return json.load(f).get("plants", [])
+
+
+def _score(query: str, name: str, aliases: list[str]) -> int:
+    """Best fuzzy score of the query against any of the plant's search handles."""
+    return max(
+        fuzz.WRatio(query, handle) for handle in (name, *aliases) if handle
+    )
+
+
+def search_catalog(q: str, type_: Optional[str] = None, limit: int = 8) -> list[dict]:
+    """Return the top-``limit`` catalog hits for ``q``, ranked best-first.
+
+    ``type_`` narrows to ``"flower"`` / ``"vegetable"``; any other value is
+    ignored (both types searched). Result shape is exactly what the frontend
+    consumes: ``{name, type, onSite, slug}``.
+    """
+    q = (q or "").strip()
+    if len(q) < _MIN_Q:
+        return []
+
+    plants = _load_catalog()
+    if type_ in ("flower", "vegetable"):
+        plants = [p for p in plants if p.get("type") == type_]
+
+    scored: list[tuple[int, dict]] = []
+    for p in plants:
+        score = _score(q, p.get("name", ""), p.get("aliases", []) or [])
+        if score >= _SCORE_FLOOR:
+            scored.append((score, p))
+
+    scored.sort(key=lambda t: t[0], reverse=True)
+    return [
+        {
+            "name": p["name"],
+            "type": p["type"],
+            "onSite": bool(p.get("onSite")),
+            "slug": p.get("slug"),
+        }
+        for _, p in scored[:limit]
+    ]

--- a/backend/database/catalog.json
+++ b/backend/database/catalog.json
@@ -725,21 +725,6 @@
       "slug": "delphinium"
     },
     {
-      "name": "Dianthus",
-      "type": "flower",
-      "aliases": [
-        "Dianthus plumarius",
-        "Pinks",
-        "Garden Pink",
-        "Sweet William",
-        "Dianthus barbatus",
-        "Bunch Pink",
-        "Bearded Pink"
-      ],
-      "onSite": true,
-      "slug": "sweet-william"
-    },
-    {
       "name": "Digitalis",
       "type": "flower",
       "aliases": [
@@ -1622,8 +1607,7 @@
       "type": "flower",
       "aliases": [
         "Melicytus ramiflorus",
-        "Whiteywood",
-        "Mahoe"
+        "Whiteywood"
       ],
       "onSite": false,
       "slug": null
@@ -1755,8 +1739,7 @@
       "type": "flower",
       "aliases": [
         "Nothofagus cliffortioides",
-        "Tawhai rauriki",
-        "Mountain Beech"
+        "Tawhai rauriki"
       ],
       "onSite": false,
       "slug": null
@@ -2505,8 +2488,7 @@
       "type": "flower",
       "aliases": [
         "Nothofagus menziesii",
-        "Tawhai",
-        "Silver Beech"
+        "Tawhai"
       ],
       "onSite": false,
       "slug": null
@@ -2578,6 +2560,17 @@
       "slug": "stock"
     },
     {
+      "name": "Strawflower",
+      "type": "flower",
+      "aliases": [
+        "Xerochrysum",
+        "Xerochrysum bracteatum",
+        "Golden Everlasting"
+      ],
+      "onSite": true,
+      "slug": "strawflower"
+    },
+    {
       "name": "Sunflower",
       "type": "flower",
       "aliases": [
@@ -2605,6 +2598,21 @@
       ],
       "onSite": true,
       "slug": "sweet-pea"
+    },
+    {
+      "name": "Sweet William",
+      "type": "flower",
+      "aliases": [
+        "Dianthus",
+        "Dianthus plumarius",
+        "Pinks",
+        "Garden Pink",
+        "Dianthus barbatus",
+        "Bunch Pink",
+        "Bearded Pink"
+      ],
+      "onSite": true,
+      "slug": "sweet-william"
     },
     {
       "name": "Tanacetum",
@@ -2958,17 +2966,6 @@
       ],
       "onSite": false,
       "slug": null
-    },
-    {
-      "name": "Xerochrysum",
-      "type": "flower",
-      "aliases": [
-        "Xerochrysum bracteatum",
-        "Strawflower",
-        "Golden Everlasting"
-      ],
-      "onSite": true,
-      "slug": "strawflower"
     },
     {
       "name": "Yarrow",
@@ -4419,22 +4416,6 @@
       "slug": null
     },
     {
-      "name": "Kokihi",
-      "type": "vegetable",
-      "aliases": [
-        "Tetragonia tetragonioides",
-        "New Zealand Spinach",
-        "Warrigal Greens",
-        "Native Spinach",
-        "Spinach",
-        "Spinacia oleracea",
-        "English Spinach",
-        "Perpetual Spinach"
-      ],
-      "onSite": true,
-      "slug": "nz-spinach"
-    },
-    {
       "name": "Komatsuna",
       "type": "vegetable",
       "aliases": [
@@ -4853,6 +4834,22 @@
       ],
       "onSite": false,
       "slug": null
+    },
+    {
+      "name": "New Zealand Spinach",
+      "type": "vegetable",
+      "aliases": [
+        "Kokihi",
+        "Tetragonia tetragonioides",
+        "Warrigal Greens",
+        "Native Spinach",
+        "Spinach",
+        "Spinacia oleracea",
+        "English Spinach",
+        "Perpetual Spinach"
+      ],
+      "onSite": true,
+      "slug": "nz-spinach"
     },
     {
       "name": "Nigella Seed",

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Dev/test-only dependencies. NOT installed into the production image
 # (backend/Dockerfile only installs requirements.txt).
 pytest==8.3.4
+httpx==0.27.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil==2.9.0
 python-jose[cryptography]==3.3.0
 bcrypt==4.2.1
 pydantic[email]==2.10.6
+rapidfuzz==3.10.1

--- a/backend/tests/test_catalog_data.py
+++ b/backend/tests/test_catalog_data.py
@@ -85,6 +85,30 @@ def test_ensure_on_site_superset_adds_missing_on_site_plants():
     assert len(plants) == n
 
 
+def test_ensure_on_site_superset_canonicalises_display_name_to_site_common_name():
+    # The catalog returned an on-site plant under one of its aliases as the
+    # primary display name — but the site calls it something different. The
+    # site's naming must win so search results match what users see elsewhere.
+    vegetables = [{"common_name": "New Zealand Spinach", "slug": "nz-spinach", "type": "leafy"}]
+    plants = [
+        {
+            "name": "Kokihi",
+            "type": "vegetable",
+            "aliases": ["Warrigal Greens", "Tetragonia"],
+            "onSite": True,
+            "slug": "nz-spinach",
+        }
+    ]
+    ensure_on_site_superset(plants, [], vegetables)
+    p = plants[0]
+    assert p["name"] == "New Zealand Spinach"
+    assert "Kokihi" in p["aliases"]
+    assert "Warrigal Greens" in p["aliases"]  # original aliases preserved
+    assert p["slug"] == "nz-spinach"
+    # The canonical name must not also appear in its own aliases.
+    assert p["aliases"].count("New Zealand Spinach") == 0
+
+
 def test_collapse_on_site_duplicates_folds_extras_into_aliases():
     plants = [
         {"name": "New Zealand Spinach", "type": "vegetable", "aliases": ["Tetragonia"], "onSite": True, "slug": "nz-spinach"},

--- a/backend/tests/test_catalog_search.py
+++ b/backend/tests/test_catalog_search.py
@@ -1,0 +1,95 @@
+"""End-to-end tests for GET /api/catalog/search via FastAPI TestClient.
+
+Points the service at a small in-file fixture catalog by monkeypatching
+``DB_PATH`` and clearing the ``lru_cache`` so each test starts from a known
+state.
+"""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import catalog_service
+
+
+FIXTURE = {
+    "plants": [
+        {"name": "Tomato", "type": "vegetable",
+         "aliases": ["Solanum lycopersicum"], "onSite": True, "slug": "tomato"},
+        {"name": "Tomatillo", "type": "vegetable",
+         "aliases": ["Physalis philadelphica"], "onSite": False, "slug": None},
+        {"name": "New Zealand Spinach", "type": "vegetable",
+         "aliases": ["Warrigal Greens", "Tetragonia"],
+         "onSite": True, "slug": "nz-spinach"},
+        {"name": "Zinnia", "type": "flower",
+         "aliases": ["Zinnia elegans"], "onSite": True, "slug": "zinnia"},
+        {"name": "Rose", "type": "flower",
+         "aliases": ["Rosa"], "onSite": False, "slug": None},
+    ]
+}
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Point the service at a temp fixture catalog and reset its cache."""
+    db = tmp_path / "catalog.json"
+    db.write_text(json.dumps(FIXTURE), encoding="utf-8")
+    monkeypatch.setattr(catalog_service, "DB_PATH", str(db))
+    catalog_service._load_catalog.cache_clear()
+    yield TestClient(app)
+    catalog_service._load_catalog.cache_clear()
+
+
+def _names(hits):
+    return [h["name"] for h in hits]
+
+
+def test_exact_prefix_beats_fuzzy_and_returns_expected_shape(client):
+    r = client.get("/api/catalog/search", params={"q": "tom"})
+    assert r.status_code == 200
+    hits = r.json()
+    assert hits, "expected at least one hit for 'tom'"
+    # Tomato / Tomatillo both start with 'tom' — one of them must be first.
+    assert hits[0]["name"] in {"Tomato", "Tomatillo"}
+    assert set(hits[0].keys()) == {"name", "type", "onSite", "slug"}
+    # On-site plants keep their real slug; requestable ones have slug None.
+    tomato = next(h for h in hits if h["name"] == "Tomato")
+    assert tomato["onSite"] is True and tomato["slug"] == "tomato"
+
+
+def test_alias_match_finds_on_site_plant_via_maori_name(client):
+    # "Warrigal" is only an ALIAS of the on-site "New Zealand Spinach".
+    hits = client.get("/api/catalog/search", params={"q": "warrigal"}).json()
+    assert hits, "alias search should find the underlying plant"
+    top = hits[0]
+    assert top["name"] == "New Zealand Spinach"
+    assert top["onSite"] is True
+    assert top["slug"] == "nz-spinach"  # real hand-set slug, not a derived one
+
+
+def test_type_filter_excludes_other_type(client):
+    hits = client.get(
+        "/api/catalog/search", params={"q": "tomato", "type": "flower"}
+    ).json()
+    assert "Tomato" not in _names(hits)  # the vegetable Tomato must be filtered out
+
+
+def test_short_query_returns_empty(client):
+    assert client.get("/api/catalog/search", params={"q": "t"}).json() == []
+    assert client.get("/api/catalog/search", params={"q": ""}).json() == []
+
+
+def test_unknown_query_returns_empty_not_error(client):
+    r = client.get("/api/catalog/search", params={"q": "xyzqqq"})
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_limit_is_respected(client):
+    hits = client.get("/api/catalog/search", params={"q": "o", "limit": 2}).json()
+    # 'o' is 1 char so under the 2-char floor -> empty regardless of limit.
+    assert hits == []
+    # A real query with a low limit caps the number of results.
+    hits = client.get("/api/catalog/search", params={"q": "tomato", "limit": 1}).json()
+    assert len(hits) <= 1

--- a/scripts/catalog/catalog_build.py
+++ b/scripts/catalog/catalog_build.py
@@ -42,22 +42,25 @@ def dedup_plants(plants: list[dict]) -> list[dict]:
     """
     merged: dict[tuple[str, str], dict] = {}
     for p in plants:
-        name = p.get("name", "")
+        name = normalize_name(p.get("name", ""))
         type_ = p.get("type", "")
-        aliases = [a for a in p.get("aliases", []) if a]
+        # An alias equal to the canonical display name is redundant clutter.
+        aliases = [
+            a for a in dict.fromkeys(p.get("aliases", []) or []) if a and a != name
+        ]
         k = _key(type_, name)
         if k not in merged:
             merged[k] = {
-                "name": normalize_name(name),
+                "name": name,
                 "type": type_,
-                "aliases": list(dict.fromkeys(aliases)),
+                "aliases": aliases,
                 "onSite": False,
                 "slug": None,
             }
         else:
             existing = merged[k]
             for a in aliases:
-                if a not in existing["aliases"]:
+                if a not in existing["aliases"] and a != existing["name"]:
                     existing["aliases"].append(a)
     return list(merged.values())
 
@@ -108,24 +111,58 @@ def ensure_on_site_superset(
     its real slug), so a plant that exists on the site is never shown as merely
     "requestable". Adds any on-site entry not already covered by name or slug.
 
+    For on-site plants already in the catalog under a different display name
+    (e.g. the model returned "Kokihi" but the site calls it "New Zealand
+    Spinach"), re-canonicalise: promote the on-site ``common_name`` to
+    ``name`` and demote the previous name into ``aliases``. The site's
+    naming is what users read on the rest of the app, so it wins.
+
     Call AFTER ``mark_on_site``. ``flowers`` map to type "flower", ``vegetables``
     to type "vegetable".
     """
+    by_slug = {p["slug"]: p for p in plants if p.get("onSite") and p.get("slug")}
     have_keys = {(p["type"], normalize_name(p["name"]).lower()) for p in plants}
-    have_slugs = {p["slug"] for p in plants if p.get("onSite") and p.get("slug")}
+
     for entries, type_ in ((flowers, "flower"), (vegetables, "vegetable")):
         for entry in entries:
-            name = normalize_name(entry.get("common_name", ""))
+            site_name = normalize_name(entry.get("common_name", ""))
             slug = entry.get("slug")
-            if not name or not slug:
+            if not site_name or not slug:
                 continue
-            if (type_, name.lower()) in have_keys or slug in have_slugs:
+
+            existing = by_slug.get(slug)
+            if existing:
+                if existing["name"] != site_name:
+                    # Fold the old display name into aliases, promote the site name.
+                    if existing["name"] and existing["name"] not in existing["aliases"]:
+                        existing["aliases"].insert(0, existing["name"])
+                    existing["name"] = site_name
+                # An alias that equals the canonical name is redundant clutter.
+                existing["aliases"] = [
+                    a for a in existing["aliases"] if a != site_name
+                ]
                 continue
+
+            if (type_, site_name.lower()) in have_keys:
+                # Already present under this name/type but not linked by slug —
+                # link it and canonicalise.
+                for p in plants:
+                    if (
+                        p["type"] == type_
+                        and normalize_name(p["name"]).lower() == site_name.lower()
+                    ):
+                        p["onSite"] = True
+                        p["slug"] = slug
+                        p["name"] = site_name
+                        by_slug[slug] = p
+                        break
+                continue
+
             plants.append(
-                {"name": name, "type": type_, "aliases": [], "onSite": True, "slug": slug}
+                {"name": site_name, "type": type_, "aliases": [], "onSite": True, "slug": slug}
             )
-            have_keys.add((type_, name.lower()))
-            have_slugs.add(slug)
+            have_keys.add((type_, site_name.lower()))
+            by_slug[slug] = plants[-1]
     return plants
 
 


### PR DESCRIPTION
Implements **E2** of the request-a-plant suggestions engine (epic #72). The catalog data from #73 stays inert until this endpoint reads it — this ships that endpoint plus a small round of data-quality fixes that showed up when live-firing it.

## Endpoint
- `backend/app/services/catalog_service.py` — rapidfuzz `WRatio` over `name` + each `alias`, score floor 60, 2-char query floor, `lru_cache`-loaded catalog.
- `backend/app/routes/catalog.py` — `GET /api/catalog/search?q=&type=&limit=`.
- `main.py` wires the router; `requirements.txt` adds `rapidfuzz==3.10.1`; `requirements-dev.txt` adds `httpx==0.27.2` for `TestClient`.

## Catalog data polish (found by live-firing)
- `ensure_on_site_superset` now **canonicalises the display name** to the site's `common_name`. Concretely: search for "warrigal" used to return `Kokihi` (a Māori name the LLM picked) even though the site calls the plant "New Zealand Spinach" — now it returns "New Zealand Spinach" with `Kokihi`/`Warrigal Greens` etc. preserved as aliases so the query still matches.
- `dedup_plants` also drops any alias that equals the canonical name (removes small clutter like `Mahoe` also appearing in its own aliases).
- `catalog.json` rebuilt with the fixed helpers — **no new LLM call**. Still 517 plants, still 56/56 on-site coverage, no canonical-in-aliases clutter.

## Testing
- `cd backend && python -m pytest` → **13 passed** (7 catalog helpers + 6 endpoint tests).
- Live-fired against the real 517-plant catalog on a local uvicorn:
  - `?q=warrigal` → New Zealand Spinach (on-site, real slug)
  - `?q=silverbeet` → Silverbeet (on-site)
  - `?q=tomato` → Tomato (requestable — genuinely not on the site yet)
  - `?q=z` → `[]` (2-char floor)

## Deploy safety
`rapidfuzz` is a pure wheel and installs cleanly. Dev deps stay in `requirements-dev.txt` (the Docker image only installs `requirements.txt`). New route inherits the existing CORS middleware.

Closes #74 · Part of #72