### PR TITLE
LLM fallback for long-tail plant suggestions (E4)

### DIFF
--- a/backend/app/routes/catalog.py
+++ b/backend/app/routes/catalog.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Query
 
+from app.services.catalog_llm_service import suggest_plants
 from app.services.catalog_service import search_catalog
 
 router = APIRouter(prefix="/api/catalog", tags=["catalog"])
@@ -14,3 +15,14 @@ def catalog_search(
     limit: int = Query(8, ge=1, le=25),
 ):
     return search_catalog(q, type, limit)
+
+
+@router.get("/suggest")
+def catalog_suggest(
+    q: str = Query("", description="Search text (returns [] if under 3 chars)"),
+    type: Optional[str] = Query(None, description="flower | vegetable"),
+    limit: int = Query(6, ge=1, le=6),
+):
+    """LLM-backed suggestions for the long tail. Frontend calls this ONLY when
+    /search returned no useful hits. Always safe: any failure -> []."""
+    return suggest_plants(q, type, limit)

--- a/backend/app/services/catalog_llm_service.py
+++ b/backend/app/services/catalog_llm_service.py
@@ -1,0 +1,117 @@
+"""LLM fallback for the long tail of plant suggestions.
+
+Only used when ``search_catalog`` returns nothing sensible. Calls the same
+hosted LLM the content pipeline already uses (DeepSeek by default) with a
+JSON-only prompt, a short timeout, and a hard result cap. Any error at all
+resolves to ``[]`` — the request path must never hang or 500 on the model.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Optional
+
+BASE_URL = os.getenv("PIPELINE_LLM_BASE_URL", "https://api.deepseek.com").rstrip("/")
+API_KEY = os.getenv("PIPELINE_LLM_API_KEY") or os.getenv("DEEPSEEK_API_KEY") or ""
+MODEL = os.getenv("PIPELINE_LLM_MODEL", "deepseek-chat")
+
+_TIMEOUT_S = 4.0
+_MAX_LIMIT = 6
+
+_PROMPT_TEMPLATE = (
+    "You are helping a New Zealand home gardener find a plant they can request. "
+    "Return up to {limit} real{type_hint} plants whose common name closely matches "
+    'or is a plausible correction / synonym of the search: "{q}". '
+    'Return ONLY minified JSON: an array of objects '
+    '{{"name": "<common name in Title Case>", "type": "flower" or "vegetable"}}. '
+    "No prose, no code fences, no explanations."
+)
+
+
+def _build_prompt(q: str, type_: Optional[str], limit: int) -> str:
+    type_hint = ""
+    if type_ == "flower":
+        type_hint = " garden cut-flower or ornamental"
+    elif type_ == "vegetable":
+        type_hint = " edible garden vegetable or herb"
+    return _PROMPT_TEMPLATE.format(q=q, type_hint=type_hint, limit=limit)
+
+
+def _call_llm(prompt: str) -> str:
+    body = json.dumps(
+        {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.2,
+            "max_tokens": 512,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{BASE_URL}/chat/completions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {API_KEY}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    return payload["choices"][0]["message"]["content"]
+
+
+def _parse_json_array(raw: str) -> list[dict]:
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        if raw.lstrip().lower().startswith("json"):
+            raw = raw.lstrip()[4:]
+    start, end = raw.find("["), raw.rfind("]")
+    if start == -1 or end == -1:
+        return []
+    try:
+        parsed = json.loads(raw[start : end + 1])
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def suggest_plants(
+    q: str, type_: Optional[str] = None, limit: int = 6
+) -> list[dict]:
+    """Return LLM-generated plant suggestions in the same shape as the catalog
+    endpoint: ``{name, type, onSite: False, slug: None}``. Always safe to call.
+
+    Guardrails:
+    - No API key configured -> ``[]``.
+    - Query shorter than 3 chars -> ``[]`` (the caller should also gate this).
+    - ``limit`` clamped to ``_MAX_LIMIT``.
+    - Anything raising (timeout, network, bad JSON, missing keys, wrong type) -> ``[]``.
+    """
+    q = (q or "").strip()
+    if not API_KEY or len(q) < 3:
+        return []
+    limit = max(1, min(int(limit or 6), _MAX_LIMIT))
+
+    try:
+        content = _call_llm(_build_prompt(q, type_, limit))
+    except (urllib.error.URLError, TimeoutError, OSError, KeyError, ValueError):
+        return []
+
+    raw_items = _parse_json_array(content)
+    hits: list[dict] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", "")).strip()
+        t = item.get("type")
+        if not name or t not in ("flower", "vegetable"):
+            continue
+        if type_ in ("flower", "vegetable") and t != type_:
+            continue
+        hits.append({"name": name, "type": t, "onSite": False, "slug": None})
+        if len(hits) >= limit:
+            break
+    return hits

--- a/backend/tests/test_catalog_llm.py
+++ b/backend/tests/test_catalog_llm.py
@@ -1,0 +1,118 @@
+"""LLM fallback tests. The DeepSeek call is patched — no real network."""
+import urllib.error
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import catalog_llm_service
+
+
+@pytest.fixture(autouse=True)
+def _set_key(monkeypatch):
+    """Every test runs with a valid API key so the "no key" short-circuit
+    doesn't hide problems; a dedicated test disables it below."""
+    monkeypatch.setattr(catalog_llm_service, "API_KEY", "test-key")
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _patch_llm(monkeypatch, value):
+    """value can be a string (raw LLM content) or an Exception to raise."""
+    def _fake(prompt):
+        if isinstance(value, BaseException):
+            raise value
+        return value
+    monkeypatch.setattr(catalog_llm_service, "_call_llm", _fake)
+
+
+def test_happy_path_parses_and_maps_to_catalog_shape(client, monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        '[{"name":"Tomatillo","type":"vegetable"},'
+        '{"name":"Cape Gooseberry","type":"vegetable"}]',
+    )
+    hits = client.get(
+        "/api/catalog/suggest", params={"q": "tomatill"}
+    ).json()
+    assert hits == [
+        {"name": "Tomatillo", "type": "vegetable", "onSite": False, "slug": None},
+        {"name": "Cape Gooseberry", "type": "vegetable", "onSite": False, "slug": None},
+    ]
+
+
+def test_type_filter_drops_wrong_type_and_bad_shapes(client, monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        '[{"name":"Rose","type":"flower"},'
+        '{"name":"Tomato","type":"vegetable"},'
+        '{"name":"Bad","type":"weed"},'
+        '{"name":"","type":"flower"},'
+        '"stringitem"]',
+    )
+    hits = client.get(
+        "/api/catalog/suggest", params={"q": "rose", "type": "flower"}
+    ).json()
+    assert hits == [
+        {"name": "Rose", "type": "flower", "onSite": False, "slug": None}
+    ]
+
+
+def test_timeout_or_network_error_returns_empty_never_raises(client, monkeypatch):
+    _patch_llm(monkeypatch, urllib.error.URLError("boom"))
+    r = client.get("/api/catalog/suggest", params={"q": "obscure"})
+    assert r.status_code == 200 and r.json() == []
+
+    _patch_llm(monkeypatch, TimeoutError())
+    r = client.get("/api/catalog/suggest", params={"q": "obscure"})
+    assert r.status_code == 200 and r.json() == []
+
+
+def test_malformed_json_returns_empty(client, monkeypatch):
+    _patch_llm(monkeypatch, "not json at all")
+    assert client.get("/api/catalog/suggest", params={"q": "obscure"}).json() == []
+
+    _patch_llm(monkeypatch, '[{"name":"Rose","type":"flower"')  # truncated
+    assert client.get("/api/catalog/suggest", params={"q": "obscure"}).json() == []
+
+
+def test_short_query_returns_empty_without_calling_llm(client, monkeypatch):
+    called = {"n": 0}
+
+    def _fake(_):
+        called["n"] += 1
+        return "[]"
+
+    monkeypatch.setattr(catalog_llm_service, "_call_llm", _fake)
+    assert client.get("/api/catalog/suggest", params={"q": "ab"}).json() == []
+    assert called["n"] == 0  # short circuit, no network
+
+
+def test_no_api_key_returns_empty_without_calling_llm(client, monkeypatch):
+    monkeypatch.setattr(catalog_llm_service, "API_KEY", "")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        catalog_llm_service, "_call_llm", lambda _: called.__setitem__("n", called["n"] + 1) or "[]"
+    )
+    assert client.get("/api/catalog/suggest", params={"q": "obscure"}).json() == []
+    assert called["n"] == 0
+
+
+def test_limit_is_clamped_to_the_max(client, monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        # eight items — endpoint caps at 6 via Query(le=6)
+        '[' + ",".join(
+            f'{{"name":"P{i}","type":"vegetable"}}' for i in range(8)
+        ) + ']',
+    )
+    # Query is validated (le=6): 25 -> 422
+    r = client.get("/api/catalog/suggest", params={"q": "obscure", "limit": 25})
+    assert r.status_code == 422
+    # a legal high limit still yields at most 6
+    r = client.get("/api/catalog/suggest", params={"q": "obscure", "limit": 6})
+    assert r.status_code == 200
+    assert len(r.json()) <= 6

--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -9,6 +9,7 @@ import {
   createPlantRequest,
   fetchRequests,
   fetchCatalogSearch,
+  fetchCatalogSuggest,
   requestLink,
   timeAgo,
   REQUEST_STATUS_META,
@@ -16,6 +17,8 @@ import {
   type PlantRequest,
 } from "@/lib/api";
 import { hitHref, pickExact } from "@/lib/catalog";
+
+type SuggestionHit = CatalogHit & { source: "catalog" | "ai" };
 
 function titleCase(s: string): string {
   return s
@@ -29,7 +32,7 @@ export default function RequestPage() {
   const { token, isLoggedIn, isLoading: authLoading } = useAuth();
   const router = useRouter();
 
-  const [hits, setHits] = useState<CatalogHit[]>([]);
+  const [hits, setHits] = useState<SuggestionHit[]>([]);
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(false);
 
@@ -60,8 +63,9 @@ export default function RequestPage() {
 
   const q = query.trim();
 
-  // Debounced remote search against the catalog. Cancels stale results if the
-  // user keeps typing or switches type.
+  // Debounced remote search against the catalog. If the static catalog has
+  // nothing useful and the query is long enough, fall back to the LLM. Both
+  // calls respect the current type toggle and cancel stale results.
   useEffect(() => {
     if (q.length < 2) {
       setHits([]);
@@ -69,8 +73,19 @@ export default function RequestPage() {
     }
     let cancelled = false;
     const id = setTimeout(async () => {
-      const results = await fetchCatalogSearch(q, plantType, 8);
-      if (!cancelled) setHits(results);
+      const staticHits = await fetchCatalogSearch(q, plantType, 8);
+      if (cancelled) return;
+      if (staticHits.length > 0) {
+        setHits(staticHits.map((h) => ({ ...h, source: "catalog" as const })));
+        return;
+      }
+      if (q.length < 3) {
+        setHits([]);
+        return;
+      }
+      const aiHits = await fetchCatalogSuggest(q, plantType, 6);
+      if (cancelled) return;
+      setHits(aiHits.map((h) => ({ ...h, source: "ai" as const })));
     }, 250);
     return () => {
       cancelled = true;
@@ -188,7 +203,7 @@ export default function RequestPage() {
                     {h.name}
                   </span>
                   <span className="ml-auto text-xs text-[var(--text-muted)] dark:text-[#A7C4A0]">
-                    Not here yet · request →
+                    {h.source === "ai" ? "AI suggestion · request →" : "Not here yet · request →"}
                   </span>
                 </button>
               );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -157,6 +157,29 @@ export async function fetchCatalogSearch(
   }
 }
 
+/**
+ * LLM-backed suggestions for the long tail. Only call this when
+ * ``fetchCatalogSearch`` returned no useful hits — the backend rate-limits it
+ * by design (empty on failure/timeout, 3-char query floor).
+ */
+export async function fetchCatalogSuggest(
+  q: string,
+  type?: "flower" | "vegetable",
+  limit = 6,
+): Promise<CatalogHit[]> {
+  const params = new URLSearchParams({ q, limit: String(limit) });
+  if (type) params.set("type", type);
+  try {
+    const res = await fetch(`${API_BASE}/api/catalog/suggest?${params}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return [];
+    return (await res.json()) as CatalogHit[];
+  } catch {
+    return [];
+  }
+}
+
 export async function fetchFlowers(region: string = "auckland"): Promise<Flower[]> {
   const res = await fetch(`${API_BASE}/api/flowers/?region=${region}`, { cache: "no-store" });
   return res.json();


### PR DESCRIPTION
Implements **E4** of the request-a-plant suggestions engine (epic #72). When the static catalog search returns nothing sensible, fall back to the same hosted DeepSeek the content pipeline uses so obscure/misspelled queries still surface useful suggestions.

## Backend
- `app/services/catalog_llm_service.py` — JSON-only DeepSeek call with a **4s timeout**, a **hard 6-result cap**, same env wiring as `scripts/pipeline/run.sh` (`PIPELINE_LLM_BASE_URL` / `PIPELINE_LLM_API_KEY` / `PIPELINE_LLM_MODEL` → `DEEPSEEK_API_KEY`).
- **Every failure mode returns `[]`** so the request path can never hang or 500 on the model: no API key, <3-char query, `URLError`/`TimeoutError`/`OSError`, malformed JSON, wrong-typed item.
- `app/routes/catalog.py` — new `GET /api/catalog/suggest?q=&type=&limit=` (server-side cap 6).
- **7 new tests** (`tests/test_catalog_llm.py`): happy path, type filter + bad shapes, `URLError`/`TimeoutError`, malformed JSON, short-query short-circuit (no LLM call), missing-API-key short-circuit, `Query(le=6)` clamp.

## Frontend
- `lib/api.ts` — `fetchCatalogSuggest()` mirrors `fetchCatalogSearch()`.
- `app/request/page.tsx` — after the debounced catalog search returns `[]`, **only if `q.length >= 3`** call `/suggest`; tag hits `source: "ai"` and render **"AI suggestion · request →"** instead of "Not here yet · request →". Otherwise UX is identical (click prefills query + type).

## Guardrails (load-bearing)
- **Local-first**: only called when the static search is empty.
- Debounce (250ms) + `q.length >= 3` gate to bound cost.
- 4s timeout, `[]` on any error, `limit ≤ 6` — the request page must never wait long or 500 on the LLM.

## Live-fired locally
- `hollyhawk` (misspelled) → **Hollyhock** + related. Typo recovery works.
- `romanesku` → **Romanesco Broccoli / Cauliflower**.
- 2-char query → `[]` (no LLM call).

## All checks
- backend pytest **20/20**, frontend vitest **8/8**, `next build` clean.

Closes #76 · Part of #72