### PR TITLE
ops: pass DeepSeek key to backend container in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,12 @@ services:
       - RUNTIME_DATA_DIR=/app/data/runtime
       - JWT_SECRET=${JWT_SECRET}
       - PIPELINE_API_KEY=${PIPELINE_API_KEY:-flower-pipeline-key-change-me}
+      # Long-tail plant-suggestion LLM fallback (GET /api/catalog/suggest).
+      # Same env wiring as scripts/pipeline/run.sh so both sides share one key.
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
+      - PIPELINE_LLM_API_KEY=${PIPELINE_LLM_API_KEY:-${DEEPSEEK_API_KEY:-}}
+      - PIPELINE_LLM_BASE_URL=${PIPELINE_LLM_BASE_URL:-https://api.deepseek.com}
+      - PIPELINE_LLM_MODEL=${PIPELINE_LLM_MODEL:-deepseek-chat}
     networks:
       - flower-network
     healthcheck:


### PR DESCRIPTION
Follow-up to #80 (E4 LLM fallback).

The prod `docker-compose.prod.yml` wasn't forwarding any LLM env into the backend container, so `GET /api/catalog/suggest` silently returned `[]` on live auckland.garden even after deploy (the "no API key" short-circuit was firing). Diagnosed by `docker exec` into `flower-garden-backend-1` — both `DEEPSEEK_API_KEY` and `PIPELINE_LLM_API_KEY` were empty.

Fix: add the passthroughs the pipeline already uses, defaulting through host env (which already has `DEEPSEEK_API_KEY` set in `/opt/flower-garden-project/.env`). Nothing else changes.

After merge + deploy: `curl -s "https://auckland.garden/api/catalog/suggest?q=hollyhawk&type=flower"` should return real suggestions instead of `[]`.