### PR TITLE
Non-interactive Hermes/Portal image-gen helper + photorealism baseline (H2)

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
-testpaths = tests
+# tests = FastAPI + pure catalog-helper tests (this dir).
+# ../scripts/pipeline/tests = ops-adjacent helper tests (hermes_image, etc.);
+# run from backend/ so we share the venv with pytest + httpx installed.
+testpaths = tests ../scripts/pipeline/tests

--- a/docs/hermes/install-log.md
+++ b/docs/hermes/install-log.md
@@ -102,6 +102,20 @@ H2's `generate_stage_image()` should build on:
   exit code alone; Hermes may exit 0 while reporting a tool failure.
 - Capture `stderr` to a log so cron doesn't email you a wall of ANSI.
 
+## Prompt-shape gotcha for photorealism (found during H2)
+
+Hermes' image-gen tool defaults to whatever style the prompt implies. A
+prompt like *"a tomato, watercolor style"* returns a watercolor; a bare
+*"a tomato"* often returns a stylised or illustrated result. The site's
+existing images are **hyper-realistic DSLR-style photographs**, so callers
+must force that explicitly. `scripts/pipeline/hermes_image.py` bakes a
+mandatory photorealism specification into every wrapped prompt (see the
+module's `PHOTOREALISM_SPEC` constant) — do not bypass it.
+
+Verified once against Portal: prompt *"a rocket (Eruca sativa) seedling in
+dark garden soil"* + the spec → sharp 1024×576 PNG, natural daylight,
+realistic leaf/soil textures, no artefacts. Attached to PR #86 and #84's PR.
+
 ## What's deliberately not set up yet
 
 - `hermes gateway` (Telegram/Discord/etc.). Skipped — outside this feature.

--- a/scripts/pipeline/hermes_image.py
+++ b/scripts/pipeline/hermes_image.py
@@ -1,0 +1,144 @@
+"""Non-interactive Hermes/Portal image-gen helper for the plant pipeline.
+
+Wraps ``hermes -z PROMPT`` (one-shot mode) so callers get a simple
+``generate_stage_image(prompt, out_path)`` and don't have to know anything
+about Hermes' TTY behaviour or Portal wiring. Safe to run from cron.
+
+Anchor for the invocation choice is in ``docs/hermes/install-log.md``.
+
+Nothing here imports from Hermes; we shell out to the installed CLI so this
+module stays trivially unit-testable (mock ``subprocess.run``).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+
+log = logging.getLogger("hermes_image")
+
+# Prefer the cron-safe absolute path we captured during H1. Cron does NOT
+# source ``~/.profile`` on the ProDesk, so the shim on ``~/.local/bin`` won't
+# be on PATH unless we ask explicitly. Fall back to whatever ``hermes`` the
+# environment provides (dev boxes, CI mocks) so tests can override at will.
+DEFAULT_HERMES_PATH = os.environ.get(
+    "HERMES_BIN", "/home/tauriq/.local/bin/hermes"
+)
+
+
+def _resolve_hermes_binary() -> str | None:
+    if os.path.isfile(DEFAULT_HERMES_PATH) and os.access(DEFAULT_HERMES_PATH, os.X_OK):
+        return DEFAULT_HERMES_PATH
+    return shutil.which("hermes")
+
+
+# Baseline photorealism specification applied to every call. Matches the
+# hyper-realistic look of the existing site images so pipeline-generated
+# fallbacks are indistinguishable from the Wikimedia-sourced ones. Callers
+# pass in the plant-specific description; this wrapper prevents anyone from
+# accidentally landing an illustration / watercolor / stylised render on the
+# site.
+PHOTOREALISM_SPEC = (
+    "Hyper-realistic professional photograph, DSLR quality, sharp focus, "
+    "natural outdoor daylight, home garden setting, shallow depth of field. "
+    "Realistic textures on leaves and soil. Single subject, no people, "
+    "no hands, no text, no watermarks, no labels, no illustrations, no "
+    "cartoon or painterly stylisation. 4:3 landscape framing."
+)
+
+
+def _build_prompt(prompt: str, out_path: str) -> str:
+    """Compose the one-shot instruction. Hermes reads this on a single turn,
+    calls the image-gen tool, and writes the file directly to ``out_path``.
+
+    ``prompt`` is the plant/stage-specific description (e.g. ``"a Kumara plant
+    at seedling stage, cotyledons emerging from dark soil"``). The wrapper
+    forces the photorealism spec around it and instructs Hermes to produce
+    the file directly without narration.
+    """
+    return (
+        f"Generate an image and save it to {out_path}.\n\n"
+        f"Subject: {prompt}\n\n"
+        f"Style requirements (mandatory): {PHOTOREALISM_SPEC}\n\n"
+        "Do not summarise or narrate the result. If the image tool fails, "
+        "exit without creating a placeholder file."
+    )
+
+
+def generate_stage_image(
+    prompt: str,
+    out_path: str,
+    timeout_s: int = 90,
+    hermes_bin: str | None = None,
+) -> bool:
+    """Generate a single image at ``out_path`` via Hermes/Portal.
+
+    Returns ``True`` if a non-empty file exists at ``out_path`` after the
+    call, ``False`` on any failure. Never raises.
+
+    Guardrails:
+    - Uses the absolute Hermes path so it works under cron.
+    - Hard timeout at ``timeout_s`` (default 90 s).
+    - **Verifies the file** afterwards — Hermes can exit 0 while reporting a
+      tool failure, so we don't trust the exit code alone.
+    - Captures stdout/stderr; the caller gets a clear log line, cron doesn't
+      get a wall of ANSI in an email.
+    """
+    hermes = hermes_bin or _resolve_hermes_binary()
+    if not hermes:
+        log.warning(
+            "hermes binary not found (looked at %s and PATH); skipping image gen",
+            DEFAULT_HERMES_PATH,
+        )
+        return False
+
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    if os.path.exists(out_path):
+        # Guarantee we can distinguish a stale file from a fresh generation.
+        try:
+            os.remove(out_path)
+        except OSError:
+            pass
+
+    composed = _build_prompt(prompt, out_path)
+    try:
+        result = subprocess.run(
+            [hermes, "-z", composed],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        log.warning("hermes image gen timed out after %ss for %s", timeout_s, out_path)
+        return False
+    except OSError as e:
+        log.warning("hermes image gen failed to launch: %s", e)
+        return False
+
+    if result.returncode != 0:
+        log.warning(
+            "hermes exited %s for %s: %s",
+            result.returncode,
+            out_path,
+            (result.stderr or result.stdout or "").strip()[:400],
+        )
+        return False
+
+    try:
+        size = os.path.getsize(out_path)
+    except OSError:
+        log.warning(
+            "hermes exited 0 but produced no file at %s (stdout tail: %s)",
+            out_path,
+            (result.stdout or "").strip()[-200:],
+        )
+        return False
+
+    if size < 1024:  # Anything under 1 KB is not a real plant photo.
+        log.warning("hermes produced a tiny file (%s bytes) at %s", size, out_path)
+        return False
+
+    log.info("hermes image ok: %s (%s bytes)", out_path, size)
+    return True

--- a/scripts/pipeline/tests/test_hermes_image.py
+++ b/scripts/pipeline/tests/test_hermes_image.py
@@ -1,0 +1,149 @@
+"""Unit tests for the Hermes image-gen helper.
+
+Every test mocks subprocess so we never actually call Hermes (and never spend
+Portal credits from a CI run). One real-world run against Portal from the
+ProDesk is the acceptance check for #84 — see the PR description.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import hermes_image
+from hermes_image import PHOTOREALISM_SPEC, generate_stage_image
+
+
+@pytest.fixture
+def out_path(tmp_path: Path) -> str:
+    return str(tmp_path / "img.png")
+
+
+@pytest.fixture(autouse=True)
+def _fake_hermes_bin(monkeypatch, tmp_path: Path) -> str:
+    """Pretend the hermes binary exists so we don't hit the resolver's real
+    filesystem lookup. Tests that care about resolution override this."""
+    fake = tmp_path / "hermes-bin"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setattr(hermes_image, "DEFAULT_HERMES_PATH", str(fake))
+    return str(fake)
+
+
+def _fake_completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["hermes"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_happy_path_writes_file_and_returns_true(out_path):
+    def _run(cmd, *_a, **_kw):
+        # Simulate Hermes producing the requested file.
+        Path(out_path).write_bytes(b"x" * 4096)
+        return _fake_completed(0, "Saved.")
+
+    with patch.object(subprocess, "run", side_effect=_run):
+        assert generate_stage_image("a Kumara seedling", out_path) is True
+    assert os.path.getsize(out_path) == 4096
+
+
+def test_prompt_carries_photorealism_spec_and_out_path(out_path):
+    captured = {}
+
+    def _run(cmd, *_a, **_kw):
+        # cmd = [hermes_bin, "-z", "<composed prompt>"]
+        captured["prompt"] = cmd[2]
+        Path(out_path).write_bytes(b"x" * 4096)
+        return _fake_completed(0)
+
+    with patch.object(subprocess, "run", side_effect=_run):
+        assert generate_stage_image("a Kumara seedling in dark soil", out_path) is True
+
+    p = captured["prompt"]
+    assert out_path in p
+    assert "a Kumara seedling in dark soil" in p
+    # Every call must be forced to hyper-realistic — this is the whole
+    # point of the wrapper baseline.
+    assert PHOTOREALISM_SPEC in p
+    assert "Hyper-realistic" in p
+    assert "no cartoon" in p.lower() or "no watermarks" in p.lower()
+
+
+def test_timeout_returns_false_and_does_not_raise(out_path):
+    def _run(cmd, *_a, **kw):
+        raise subprocess.TimeoutExpired(cmd, kw.get("timeout", 90))
+
+    with patch.object(subprocess, "run", side_effect=_run):
+        assert generate_stage_image("anything", out_path, timeout_s=1) is False
+    assert not os.path.exists(out_path)
+
+
+def test_nonzero_exit_returns_false(out_path):
+    with patch.object(
+        subprocess, "run", return_value=_fake_completed(2, stderr="boom")
+    ):
+        assert generate_stage_image("anything", out_path) is False
+
+
+def test_exit_zero_but_no_file_returns_false(out_path):
+    # Hermes sometimes exits 0 while the tool call actually failed — this is
+    # exactly the case the "verify file exists" guard exists to catch.
+    with patch.object(
+        subprocess, "run", return_value=_fake_completed(0, "Sorry, tool errored")
+    ):
+        assert generate_stage_image("anything", out_path) is False
+
+
+def test_tiny_output_file_treated_as_failure(out_path):
+    def _run(cmd, *_a, **_kw):
+        Path(out_path).write_bytes(b"tiny")  # 4 bytes
+        return _fake_completed(0)
+
+    with patch.object(subprocess, "run", side_effect=_run):
+        assert generate_stage_image("anything", out_path) is False
+
+
+def test_missing_hermes_binary_returns_false(monkeypatch, out_path, tmp_path):
+    monkeypatch.setattr(
+        hermes_image, "DEFAULT_HERMES_PATH", str(tmp_path / "nope")
+    )
+    monkeypatch.setattr(hermes_image.shutil, "which", lambda _n: None)
+    # Should never even reach subprocess.
+    with patch.object(subprocess, "run") as run:
+        assert generate_stage_image("anything", out_path) is False
+        run.assert_not_called()
+
+
+def test_stale_output_file_is_removed_before_generation(out_path):
+    Path(out_path).write_bytes(b"stale content from a previous run")
+
+    with patch.object(subprocess, "run", return_value=_fake_completed(1)):
+        assert generate_stage_image("anything", out_path) is False
+    # The stale bytes must NOT still be there after a failed run.
+    assert not os.path.exists(out_path)
+
+
+def test_explicit_hermes_bin_override_is_honoured(out_path, tmp_path):
+    override = tmp_path / "custom-hermes"
+    override.write_text("")
+    captured = {}
+
+    def _run(cmd, *_a, **_kw):
+        captured["bin"] = cmd[0]
+        Path(out_path).write_bytes(b"x" * 4096)
+        return _fake_completed(0)
+
+    with patch.object(subprocess, "run", side_effect=_run):
+        assert (
+            generate_stage_image(
+                "anything", out_path, hermes_bin=str(override)
+            )
+            is True
+        )
+    assert captured["bin"] == str(override)


### PR DESCRIPTION
Implements **H2** of the Hermes-agent epic (#82). Ships the seam H3 uses.

## What
`scripts/pipeline/hermes_image.py` — cron-safe wrapper around `hermes -z PROMPT` (the one-shot mode discovered during H1). Single entry:

```python
def generate_stage_image(prompt: str, out_path: str, timeout_s: int = 90) -> bool
```

Guardrails baked in:
- Absolute Hermes path (`/home/tauriq/.local/bin/hermes`) so it works under cron (`~/.profile` not sourced there).
- Hard timeout at 90s.
- **File-existence + size (>=1 KB) check after the call** — Hermes sometimes exits 0 while reporting a tool failure. Exit code alone is not enough.
- Stale file at `out_path` removed before generation so a failed run can never leave old bytes behind.
- Captured stdout/stderr; cron gets clean single-line log.

## Photorealism baseline (load-bearing)
`PHOTOREALISM_SPEC` forces every generated image to **hyper-realistic DSLR quality** with natural daylight, sharp focus, no cartoon/watercolor styling, no watermarks/text/people. Matches the site's existing image style so pipeline fallbacks are indistinguishable from the Wikimedia-sourced originals. Callers supply the plant/stage description; the wrapper composes the full prompt so nobody can accidentally land an illustration on the site.

## Tests — 9 new, no network
- Happy path writes a real-sized file → True.
- Prompt carries the photorealism spec + `out_path`.
- `TimeoutExpired` → False (no raise).
- Non-zero exit → False.
- Exit 0 with no output file → False (Hermes drift caught).
- Tiny (<1 KB) output → False.
- Missing binary → False without ever calling subprocess.
- Stale `out_path` is removed before and after a failed run.
- `hermes_bin` override honoured.

`cd backend && python -m pytest` → **29 passed** (20 existing + 9 new).

## Real-world verification (one Portal call from ProDesk)
Prompt: *"a rocket (Eruca sativa) seedling in dark garden soil"* + `PHOTOREALISM_SPEC` →

**1024×576 PNG, 1.1 MB, exit 0, ~30s wall clock.** DSLR-quality photorealism, natural outdoor daylight, sharp focus, realistic soil/leaf texture, no artefacts. This is the seam H3 (#85) plugs into the pipeline as a Wikimedia fallback.

## Wiring notes for H3
- Import: `from hermes_image import generate_stage_image`
- Call once per failed stage; use `path=/tmp/pipeline-staging/<slug>/<stage>.png` then move.
- Log `image %s: source=hermes path=%s` per stage (H3 acceptance).
- Cost cap: at most 3 fallback calls per plant.

Closes #84 · Part of #82