### PR TITLE
Fix session-expiry UX + auto-clear stale auth + dropdown close on pick

### DIFF
--- a/frontend/src/app/request/page.tsx
+++ b/frontend/src/app/request/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Search, Sprout, ArrowRight } from "lucide-react";
 import { useAuth } from "@/lib/auth";
+import { useAuthModal } from "@/lib/auth-modal";
 import {
   createPlantRequest,
   fetchRequests,
@@ -30,6 +31,7 @@ function titleCase(s: string): string {
 
 export default function RequestPage() {
   const { token, isLoggedIn, isLoading: authLoading } = useAuth();
+  const { openAuthModal } = useAuthModal();
   const router = useRouter();
 
   const [hits, setHits] = useState<SuggestionHit[]>([]);
@@ -40,6 +42,11 @@ export default function RequestPage() {
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  // Set synchronously alongside setSessionExpired(true) so the route-guard
+  // effect can see "user is mid-flow, keep them here" even if the auth
+  // clear + re-render arrives before the sessionExpired state update does.
+  const staySignedOutOnPageRef = useRef(false);
   const [justCreated, setJustCreated] = useState<PlantRequest | null>(null);
 
   const [requests, setRequests] = useState<PlantRequest[]>([]);
@@ -48,11 +55,24 @@ export default function RequestPage() {
   useEffect(() => {
     if (authLoading) return;
     if (!isLoggedIn || !token) {
+      // Stay put if the user just tripped a session-expired submit — the
+      // in-page panel prompts a fresh sign-in without losing their draft.
+      // Otherwise (cold-load with no session) send them home to sign in.
+      if (staySignedOutOnPageRef.current) return;
       router.replace("/");
       return;
     }
     loadAll();
   }, [isLoggedIn, token, authLoading]);
+
+  // If the user signs back in via the modal, resume the page state.
+  useEffect(() => {
+    if (isLoggedIn && staySignedOutOnPageRef.current) {
+      staySignedOutOnPageRef.current = false;
+      setSessionExpired(false);
+      if (token) loadAll();
+    }
+  }, [isLoggedIn, token]);
 
   async function loadAll() {
     if (!token) return;
@@ -106,6 +126,7 @@ export default function RequestPage() {
     }
     setSubmitting(true);
     setError(null);
+    setSessionExpired(false);
     setJustCreated(null);
 
     const { request, error: err } = await createPlantRequest(token, {
@@ -114,7 +135,13 @@ export default function RequestPage() {
       notes: notes.trim() || undefined,
     });
 
-    if (err) {
+    if (err === "SESSION_EXPIRED") {
+      // Draft (query/type/notes) is retained in state so the user can
+      // sign in and re-submit without losing what they typed. The ref
+      // is what the route-guard checks before redirecting.
+      staySignedOutOnPageRef.current = true;
+      setSessionExpired(true);
+    } else if (err) {
       setError(err);
     } else if (request) {
       setJustCreated(request);
@@ -195,6 +222,11 @@ export default function RequestPage() {
                   onClick={() => {
                     setPlantType(h.type);
                     setQuery(h.name);
+                    // Close the dropdown so the user's next click can be the
+                    // Request button instead of another suggestion. Without
+                    // this, setQuery re-fires the debounced search and the
+                    // dropdown just re-populates with slightly different hits.
+                    setFocused(false);
                   }}
                   className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-[var(--forest-50)] dark:hover:bg-[#1B4332]/50 transition"
                 >
@@ -277,7 +309,33 @@ export default function RequestPage() {
       )}
 
       {/* Error */}
-      {!exactMatch && error && (
+      {/* Session expired — friendlier than the raw "Invalid or expired token"
+          detail the backend returns. Draft is retained in state so signing in
+          again lets the user submit without retyping. */}
+      {!exactMatch && sessionExpired && (
+        <div className="mt-4 p-4 rounded-xl border border-amber-200 dark:border-[#2e2515] bg-amber-50/60 dark:bg-[#2e2515]/30">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="font-semibold text-[var(--forest)] dark:text-[#4CAF50]">
+                Your sign-in has expired
+              </p>
+              <p className="text-sm text-[var(--text-muted)] dark:text-[#A7C4A0] mt-0.5">
+                Sign in again to send this request — we&apos;ve kept
+                what you typed.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => openAuthModal("signin")}
+              className="shrink-0 px-4 py-2 rounded-[var(--radius-sm)] text-sm font-semibold bg-[var(--forest)] text-white hover:bg-[var(--forest-600)] dark:bg-[#2D6A4F] dark:hover:bg-[#40916C] transition"
+            >
+              Sign in
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!exactMatch && !sessionExpired && error && (
         <div className="mt-4 p-4 rounded-xl border border-red-200 dark:border-red-900/40 bg-red-50/60 dark:bg-red-900/20 text-sm text-red-700 dark:text-red-300">
           {error}
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,20 @@
 import Link from "next/link";
 
+import { dispatchAuthExpired } from "./auth";
+
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+
+/**
+ * Any 401 from an authed endpoint means the JWT is invalid or past its
+ * 7-day expiry. Dispatch the auth-expired event so the ``AuthProvider``
+ * clears the local session and the UI stops showing signed-in state.
+ * Returns ``true`` if the caller should treat this as an expired session.
+ */
+function _isSessionExpired(res: Response): boolean {
+  if (res.status !== 401) return false;
+  dispatchAuthExpired();
+  return true;
+}
 
 export interface GrowthStages {
   harvest: string | null;
@@ -572,7 +586,10 @@ export async function fetchNotifications(token: string, limit: number = 100): Pr
     cache: "no-store",
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) return [];
+  if (!res.ok) {
+    _isSessionExpired(res);
+    return [];
+  }
   return res.json();
 }
 
@@ -581,7 +598,10 @@ export async function fetchUnreadCount(token: string): Promise<number> {
     cache: "no-store",
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) return 0;
+  if (!res.ok) {
+    _isSessionExpired(res);
+    return 0;
+  }
   const data = await res.json();
   return data.count ?? 0;
 }
@@ -669,7 +689,10 @@ export async function fetchRequests(token: string): Promise<PlantRequest[]> {
     cache: "no-store",
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) return [];
+  if (!res.ok) {
+    _isSessionExpired(res);
+    return [];
+  }
   return res.json();
 }
 
@@ -686,6 +709,12 @@ export async function createPlantRequest(
     body: JSON.stringify(data),
   });
   if (!res.ok) {
+    // 401 => the session has expired. Surface a stable code so the UI can
+    // show a "Sign in again" affordance instead of the backend's raw
+    // "Invalid or expired token" detail. Also clear the local session.
+    if (_isSessionExpired(res)) {
+      return { request: null, error: "SESSION_EXPIRED" };
+    }
     let error = "Couldn't submit your request. Please try again.";
     try {
       const body = await res.json();

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -11,6 +11,20 @@ import {
 const TOKEN_KEY = "flower_garden_token";
 const USER_KEY = "flower_garden_user";
 
+/**
+ * Custom event dispatched from ``api.ts`` when an authed request returns
+ * a 401 — most commonly a stale JWT that has passed its 7-day expiry. The
+ * ``AuthProvider`` listens for it and clears the local session so the UI
+ * stops showing a "signed in" state that no longer works.
+ */
+export const AUTH_EXPIRED_EVENT = "flower-garden:auth-expired";
+
+/** Dispatch from anywhere a fetch sees a 401. Safe to call in SSR. */
+export function dispatchAuthExpired(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
+}
+
 export interface User {
   id: string;
   email: string;
@@ -48,6 +62,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     }
     setIsLoading(false);
+  }, []);
+
+  // Listen for auth-expired events dispatched by api.ts on any 401. Clears
+  // the local session so the UI stops advertising "signed in" state that
+  // no longer works. A stale token was the cause of the "Invalid or expired
+  // token" error users hit on the request page.
+  useEffect(() => {
+    const onExpired = () => {
+      setUser(null);
+      setToken(null);
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
+    };
+    window.addEventListener(AUTH_EXPIRED_EVENT, onExpired);
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onExpired);
   }, []);
 
   const login = (user: User, token: string) => {


### PR DESCRIPTION
Three bugs found on live use of `/request`:

## 1. "Invalid or expired token" copy → actionable panel
Submitting after the 7-day JWT expired surfaced the raw backend detail. Replaced with an amber panel: **"Your sign-in has expired · Sign in again to send this request — we've kept what you typed."** and a **Sign in** button that opens the existing auth modal. Query, plant type, and notes are retained in state so re-submitting after sign-in doesn't lose the draft.

## 2. Global stale-auth cleanup
The UI kept advertising "signed in" (nav Sign-out link, notification poll firing continuously) while every authed request 401'd server-side. Introduced a `flower-garden:auth-expired` custom event dispatched from `api.ts` whenever an authed endpoint returns 401 (`createPlantRequest`, `fetchRequests`, `fetchNotifications`, `fetchUnreadCount`). `AuthProvider` listens for it and clears `localStorage` + React state so the whole UI reflects reality.

## 3. Dropdown didn't close on suggestion pick
Clicking a "Not here yet · request" suggestion set the query and re-fired the debounced search, so the dropdown re-populated instead of closing. Added `setFocused(false)` on pick.

## Race fix
Auto-clearing auth on submit-time 401 would trip the route guard's `router.replace("/")` before the friendly panel could render. Guarded with a ref (`staySignedOutOnPageRef`) set synchronously alongside `setSessionExpired(true)`. Cold-load with no session still redirects; mid-flow expiry stays put.

`createPlantRequest` now returns a stable `"SESSION_EXPIRED"` string so the page can branch without matching backend copy.

## Live verification in Brave
- Signed in for real, patched `fetch` to force 401 on `POST /api/requests/`, clicked Chickpea → dropdown closed, form prefilled. Clicked Request → **amber "Your sign-in has expired" panel** with Sign in button, draft retained, nav flipped to "Sign in", localStorage cleared, no redirect.
- Cold-load with expired token → notification/requests polls 401 → dispatch → auth cleared → redirect to home. Correct.

`next build` clean, backend pytest **36/36**, frontend vitest **8/8**.